### PR TITLE
disable uploading and signing

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -64,18 +64,5 @@
 			<zipgroupfileset dir="libs" excludes="META-INF/*.SF" includes="**/*.jar" />
 		</jar>
 
-		<signjar jar="${project.name}.jar" keystore="http://dakror.de/bin/dakrorKeystore.jks" alias="dakror"
-			storepass="dakrorKeystore" />
-
-		<echo message="starting FTP file upload" />
-		<java classname="de.dakror.dakrorbin.Uploader">
-			<arg value="${project.name}" />
-			<classpath>
-				<pathelement location="bin/Uploader.jar" />
-				<pathelement path="${java.class.path}" />
-			</classpath>
-		</java>
-
-		<delete dir="bin" />
 	</target>
 </project>


### PR DESCRIPTION
A temporary(?) workaround.

Signing and uploading should be an option since not everyone is Dakror. 
Without this patch building of the game is blocked.